### PR TITLE
Mitigate startup TF issue

### DIFF
--- a/fixposition_driver_lib/src/odometry.cpp
+++ b/fixposition_driver_lib/src/odometry.cpp
@@ -137,8 +137,9 @@ void OdometryConverter::ConvertTokens(const std::vector<std::string>& tokens) {
             q_ecef_enu0_ = Eigen::Quaterniond(gnss_tf::RotEnuEcef(t_ecef_body).transpose());
             msgs_.tf_ecef_enu0.translation = t_ecef_enu0_;
             msgs_.tf_ecef_enu0.rotation = q_ecef_enu0_;
-            bool tf_is_nan = isnan(msgs_.tf_ecef_enu0.rotation.x()) || isnan(msgs_.tf_ecef_enu0.rotation.y()) || isnan(msgs_.tf_ecef_enu0.rotation.z()) || isnan(msgs_.tf_ecef_enu0.rotation.w());
-            if (!tf_is_nan) {
+            bool tf_rot_is_nan = isnan(msgs_.tf_ecef_enu0.rotation.x()) || isnan(msgs_.tf_ecef_enu0.rotation.y()) || isnan(msgs_.tf_ecef_enu0.rotation.z()) || isnan(msgs_.tf_ecef_enu0.rotation.w());
+            bool tf_trans_is_nan = isnan(msgs_.tf_ecef_enu0.translation.x()) || isnan(msgs_.tf_ecef_enu0.translation.y()) || isnan(msgs_.tf_ecef_enu0.translation.z());
+            if (!tf_rot_is_nan && !tf_trans_is_nan) {
                 tf_ecef_enu0_set_ = true;
             }
         

--- a/fixposition_driver_lib/src/odometry.cpp
+++ b/fixposition_driver_lib/src/odometry.cpp
@@ -137,7 +137,11 @@ void OdometryConverter::ConvertTokens(const std::vector<std::string>& tokens) {
             q_ecef_enu0_ = Eigen::Quaterniond(gnss_tf::RotEnuEcef(t_ecef_body).transpose());
             msgs_.tf_ecef_enu0.translation = t_ecef_enu0_;
             msgs_.tf_ecef_enu0.rotation = q_ecef_enu0_;
-            tf_ecef_enu0_set_ = true;
+            bool tf_is_nan = isnan(msgs_.tf_ecef_enu0.rotation.x()) || isnan(msgs_.tf_ecef_enu0.rotation.y()) || isnan(msgs_.tf_ecef_enu0.rotation.z()) || isnan(msgs_.tf_ecef_enu0.rotation.w());
+            if (!tf_is_nan) {
+                tf_ecef_enu0_set_ = true;
+            }
+        
         }
 
         // TF ECEF POI is basically the same as the odometry, containing the Pose of the POI in the ECEF Frame

--- a/fixposition_driver_ros1/src/fixposition_driver_node.cpp
+++ b/fixposition_driver_ros1/src/fixposition_driver_node.cpp
@@ -160,7 +160,10 @@ void FixpositionDriverNode::RegisterObservers() {
                     imu_ypr.header.frame_id = "FP_POI";
                     tf::vectorEigenToMsg(imu_ypr_eigen, imu_ypr.vector);
                     eul_imu_pub_.publish(imu_ypr);
-
+                } else if (tf.header.frame_id == "FP_ENU0") {
+                    if (!isnan(tf.transform.rotation.x) && !isnan(tf.transform.rotation.y) && !isnan(tf.transform.rotation.z) && !isnan(tf.transform.rotation.w)) {
+                        static_br_.sendTransform(tf);
+                    }
                 } else {
                     static_br_.sendTransform(tf);
                 }

--- a/fixposition_driver_ros1/src/fixposition_driver_node.cpp
+++ b/fixposition_driver_ros1/src/fixposition_driver_node.cpp
@@ -160,7 +160,7 @@ void FixpositionDriverNode::RegisterObservers() {
                     imu_ypr.header.frame_id = "FP_POI";
                     tf::vectorEigenToMsg(imu_ypr_eigen, imu_ypr.vector);
                     eul_imu_pub_.publish(imu_ypr);
-                    
+
                 } else {
                     static_br_.sendTransform(tf);
                 }

--- a/fixposition_driver_ros1/src/fixposition_driver_node.cpp
+++ b/fixposition_driver_ros1/src/fixposition_driver_node.cpp
@@ -160,10 +160,7 @@ void FixpositionDriverNode::RegisterObservers() {
                     imu_ypr.header.frame_id = "FP_POI";
                     tf::vectorEigenToMsg(imu_ypr_eigen, imu_ypr.vector);
                     eul_imu_pub_.publish(imu_ypr);
-                } else if (tf.header.frame_id == "FP_ENU0") {
-                    if (!isnan(tf.transform.rotation.x) && !isnan(tf.transform.rotation.y) && !isnan(tf.transform.rotation.z) && !isnan(tf.transform.rotation.w)) {
-                        static_br_.sendTransform(tf);
-                    }
+                    
                 } else {
                     static_br_.sendTransform(tf);
                 }


### PR DESCRIPTION
In Firmware 2.85.3, FixPosition reintroduced a bug where by for the first few cycles of publishing of the "FP_ENU", the transforms is full of NaNs which causes issues because the "FP_ENU0" transform is latched on the first cycle of "FP_ENU" transform. This causes a lot of spamming from the tf_buffer about the NaN values. This PR introduces a small check to ensure the transforms are not NaNs before publishing the "FP_ENU0" transform.

This has been tested on an independent FixPosition unit shown here:
You can see the text output (which has been removed) saying the transforms failed the NaN check
![image](https://github.com/Greenzie/fixposition_driver/assets/102085222/824d2c5e-5280-44e3-8005-83195d814153)
This shows the text output code before it was removed for this PR:
![image](https://github.com/Greenzie/fixposition_driver/assets/102085222/14edc49a-91c5-40f3-87cd-5bcb2c02565f)

Tested on a Pre-2.85.2 FP unit and it works without issues.

