### PR TITLE
Update to fixed orb

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,8 +1,7 @@
 version: 2.1
 
 orbs:
-  greenzie: greenzie/build_and_publish_debs@0.0.4
-
+  greenzie: greenzie/build_and_publish_debs@0.0.5
 
 parameters:
   manual-bobcat-deploy:
@@ -21,6 +20,7 @@ workflows:
           platform: amd64
           executor: greenzie/debianize_amd64
           clone_submodules: true
+          
 
       - greenzie/debian_build:
           name: "arm64_debian_build"

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -20,7 +20,6 @@ workflows:
           platform: amd64
           executor: greenzie/debianize_amd64
           clone_submodules: true
-          
 
       - greenzie/debian_build:
           name: "arm64_debian_build"


### PR DESCRIPTION
I made a fix in the orb to update the packages (`apt update`) in the used docker image.
It was previously working because the packages where available in the `apt` cache of the built image that is now cleaned up before finishing the build