### PR TITLE
Fix orb version (wrong aptly docker image)

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -31,10 +31,10 @@ workflows:
       - greenzie/debian_deploy_experimental:
           name: "deploy_amd64_greenzie"
           context: GREENZIE
-#          filters:
-#            branches:
-#              only:
-#                - noetic
+          filters:
+            branches:
+              only:
+                - noetic
           requires:
             - amd_debian_build
 
@@ -42,10 +42,10 @@ workflows:
           name: "deploy_arm64_greenzie"
           context: GREENZIE
           architecture: arm64
-#          filters:
-#            branches:
-#              only:
-#                - noetic
+          filters:
+            branches:
+              only:
+                - noetic
           requires:
             - arm64_debian_build
 
@@ -53,10 +53,10 @@ workflows:
           context: GREENZIE
           name: "deploy_all_bobcat"
           server_hostname: bobcat
-#          filters:
-#            branches:
-#              only:
-#                - noetic
+          filters:
+            branches:
+              only:
+                - noetic
           requires:
             - arm64_debian_build
             - amd_debian_build

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -42,10 +42,10 @@ workflows:
           name: "deploy_arm64_greenzie"
           context: GREENZIE
           architecture: arm64
-          filters:
-            branches:
-              only:
-                - noetic
+#          filters:
+#            branches:
+#              only:
+#                - noetic
           requires:
             - arm64_debian_build
 
@@ -53,10 +53,10 @@ workflows:
           context: GREENZIE
           name: "deploy_all_bobcat"
           server_hostname: bobcat
-          filters:
-            branches:
-              only:
-                - noetic
+#          filters:
+#            branches:
+#              only:
+#                - noetic
           requires:
             - arm64_debian_build
             - amd_debian_build

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,7 +1,7 @@
 version: 2.1
 
 orbs:
-  greenzie: greenzie/build_and_publish_debs@0.0.5
+  greenzie: greenzie/build_and_publish_debs@dev:fix_aptly
 
 parameters:
   manual-bobcat-deploy:
@@ -31,10 +31,10 @@ workflows:
       - greenzie/debian_deploy_experimental:
           name: "deploy_amd64_greenzie"
           context: GREENZIE
-          filters:
-            branches:
-              only:
-                - noetic
+#          filters:
+#            branches:
+#              only:
+#                - noetic
           requires:
             - amd_debian_build
 

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,7 +1,7 @@
 version: 2.1
 
 orbs:
-  greenzie: greenzie/build_and_publish_debs@0.06
+  greenzie: greenzie/build_and_publish_debs@0.0.6
 
 parameters:
   manual-bobcat-deploy:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,7 +1,7 @@
 version: 2.1
 
 orbs:
-  greenzie: greenzie/build_and_publish_debs@dev:fix_aptly
+  greenzie: greenzie/build_and_publish_debs@0.06
 
 parameters:
   manual-bobcat-deploy:


### PR DESCRIPTION
Apply this fix to the orb:
https://github.com/Greenzie/circleci-orbs/commit/b702795e12507fddaf6be3d94f43e8566dcee3b4