### PR TITLE
bump Fixposition SDK (#98)

### DIFF
--- a/fixposition_driver_lib/src/helper.cpp
+++ b/fixposition_driver_lib/src/helper.cpp
@@ -104,23 +104,23 @@ bool TwistWithCovData::SetFromFpaOdomPayload(const fpa::FpaOdomPayload& payload)
 
 bool OdometryData::SetFromFpaOdomPayload(const fpa::FpaOdomPayload& payload) {
     bool ok = true;
-    switch (payload.which) {
-        case fpa::FpaOdomPayload::Which::ODOMETRY:
+    switch (payload.msg_type_) {
+        case fpa::FpaMessageType::ODOMETRY:
             frame_id = ODOMETRY_FRAME_ID;
             child_frame_id = ODOMETRY_CHILD_FRAME_ID;
             type = Type::ODOMETRY;
             break;
-        case fpa::FpaOdomPayload::Which::ODOMSH:
+        case fpa::FpaMessageType::ODOMSH:
             frame_id = ODOMSH_FRAME_ID;
             child_frame_id = ODOMSH_CHILD_FRAME_ID;
             type = Type::ODOMSH;
             break;
-        case fpa::FpaOdomPayload::Which::ODOMENU:
+        case fpa::FpaMessageType::ODOMENU:
             frame_id = ODOMENU_FRAME_ID;
             child_frame_id = ODOMENU_CHILD_FRAME_ID;
             type = Type::ODOMENU;
             break;
-        case fpa::FpaOdomPayload::Which::UNSPECIFIED:
+        default:
             ok = false;
             type = Type::UNSPECIFIED;
             break;

--- a/fixposition_driver_ros2/CMakeLists.txt
+++ b/fixposition_driver_ros2/CMakeLists.txt
@@ -27,6 +27,7 @@ find_package(fixposition_driver_msgs REQUIRED)
 find_package(rtcm_msgs REQUIRED)
 find_package(fpsdk_common REQUIRED)
 find_package(fpsdk_ros2 REQUIRED)
+find_package(rosbag2_cpp REQUIRED)
 
 include_directories(
   include
@@ -53,6 +54,7 @@ target_link_libraries(
   ${Boost_LIBRARIES}
   ${EIGEN3_LIBRARIES}
   ${fpsdk_common_LIBRARIES} ${fpsdk_ros2_LIBRARIES}
+  ${rosbag2_cpp_TARGETS}
   pthread
 )
 


### PR DESCRIPTION
- Bump fixposition-sdk commit to latest
- Unnecessary FpaOdomPayload::Which was removed, use FpaPayload::type_ (FpaMessageType) instead
- Fix cmake config. Somehow rosbag2_cpp is now required... :-/